### PR TITLE
Added Support for Memory Limit and AWS ECR Compatibility

### DIFF
--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/DefaultService.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/DefaultService.groovy
@@ -107,6 +107,7 @@ class DefaultService extends Service {
     List<? extends Network> networks
     List<String> aliases
     String restart
+    Long memLimit
 
     /**
      * Build image specific properties (can only be used when no image is defined). Properties are optional by default.

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/Service.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/Service.groovy
@@ -227,6 +227,10 @@ abstract class Service extends AbstractEntity {
 
     abstract void setRepository(String repository)
 
+    abstract Long getMemLimit()
+
+    abstract void setMemLimit(Long memLimit)
+
     ServiceDependency link(String alias = null) {
         new ServiceDependency(alias ?: name, this)
     }

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/ServiceReference.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/ServiceReference.groovy
@@ -371,4 +371,14 @@ class ServiceReference extends Service {
     String getContainerId() {
         resolved.containerId
     }
+
+    @Override
+    Long getMemLimit() {
+        resolved.memLimit
+    }
+
+    @Override
+    void setMemLimit(Long memLimit) {
+        resolved.memLimit = memLimit
+    }
 }


### PR DESCRIPTION
- Added mem_limit support to createComposeFile task
- Added compatibility mode for AWS EC2 Container Register (ECR)
  - AWS ECR doesn't support depends_on, so you must use links
  - AWS ECR doesn't support referencing images by digest hash, you must use tag name
