### PR TITLE
Config log driver

### DIFF
--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/DefaultService.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/DefaultService.groovy
@@ -118,6 +118,7 @@ class DefaultService extends Service {
     String restart
     Long memLimit
     String logConfig
+    Map<String, String> logOpts
 
     /**
      * Build image specific properties (can only be used when no image is defined). Properties are optional by default.

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/DefaultService.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/DefaultService.groovy
@@ -117,6 +117,7 @@ class DefaultService extends Service {
     List<String> aliases
     String restart
     Long memLimit
+    String logConfig
 
     /**
      * Build image specific properties (can only be used when no image is defined). Properties are optional by default.

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/Service.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/Service.groovy
@@ -242,6 +242,10 @@ abstract class Service extends AbstractEntity {
 
     abstract void setMemLimit(Long memLimit)
 
+    abstract String getLogConfig()
+
+    abstract void setLogConfig(String logConfig)
+
     ServiceDependency link(String alias = null) {
         new ServiceDependency(alias ?: name, this)
     }

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/Service.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/Service.groovy
@@ -246,6 +246,10 @@ abstract class Service extends AbstractEntity {
 
     abstract void setLogConfig(String logConfig)
 
+    abstract Map<String, String> getLogOpts()
+
+    abstract void setLogOpts(Map<String, String> logOpts)
+
     ServiceDependency link(String alias = null) {
         new ServiceDependency(alias ?: name, this)
     }

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/ServiceReference.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/ServiceReference.groovy
@@ -397,4 +397,14 @@ class ServiceReference extends Service {
     void setMemLimit(Long memLimit) {
         resolved.memLimit = memLimit
     }
+
+    @Override
+    String getLogConfig() {
+        resolved.logConfig
+    }
+
+    @Override
+    void setLogConfig(String logConfig) {
+        resolved.logConfig = logConfig
+    }
 }

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/ServiceReference.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/extension/ServiceReference.groovy
@@ -407,4 +407,14 @@ class ServiceReference extends Service {
     void setLogConfig(String logConfig) {
         resolved.logConfig = logConfig
     }
+
+    @Override
+    Map<String, String> getLogOpts() {
+        resolved.logOpts
+    }
+
+    @Override
+    void setLogOpts(Map<String, String> logOpts) {
+        resolved.logOpts = logOpts
+    }
 }

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTask.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTask.groovy
@@ -200,6 +200,9 @@ class DcomposeComposeFileTask extends AbstractDcomposeTask {
                     if (service.memLimit) {
                         spec.mem_limit = service.memLimit
                     }
+                    if (service.logConfig) {
+                        spec.logging = [driver: service.logConfig]
+                    }
                     break;
 
                 case '3':
@@ -215,6 +218,9 @@ class DcomposeComposeFileTask extends AbstractDcomposeTask {
                     }
                     if (service.memLimit) {
                         spec.deploy.resources.limits.memory = service.memLimit.toString()
+                    }
+                    if (service.logConfig) {
+                        spec.logging = [driver: service.logConfig]
                     }
                     break;
 

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTask.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTask.groovy
@@ -184,6 +184,10 @@ class DcomposeComposeFileTask extends AbstractDcomposeTask {
                     spec.networks = networksSpec
                 }
             }
+            if (service.logConfig) {
+                spec.logging = [driver: service.logConfig]
+                if (service.logOpts) spec.logging << [options: service.logOpts]
+            }
 
             switch (version) {
                 case '2':
@@ -200,9 +204,6 @@ class DcomposeComposeFileTask extends AbstractDcomposeTask {
                     if (service.memLimit) {
                         spec.mem_limit = service.memLimit
                     }
-                    if (service.logConfig) {
-                        spec.logging = [driver: service.logConfig]
-                    }
                     break;
 
                 case '3':
@@ -218,9 +219,6 @@ class DcomposeComposeFileTask extends AbstractDcomposeTask {
                     }
                     if (service.memLimit) {
                         spec.deploy.resources.limits.memory = service.memLimit.toString()
-                    }
-                    if (service.logConfig) {
-                        spec.logging = [driver: service.logConfig]
                     }
                     break;
 

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/container/DcomposeContainerCreateTask.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/container/DcomposeContainerCreateTask.groovy
@@ -263,6 +263,12 @@ class DcomposeContainerCreateTask extends AbstractDcomposeServiceTask {
         service.cpusetcpus
     }
 
+    @Input
+    @Optional
+    String getLogConfig() {
+        service.logConfig
+    }
+
     @TaskAction
     @TypeChecked(TypeCheckingMode.SKIP)
     void createNewContainer() {
@@ -397,6 +403,13 @@ class DcomposeContainerCreateTask extends AbstractDcomposeServiceTask {
 
             if (networkMode) {
                 cmd.withNetworkMode(networkMode)
+            }
+
+            if (logConfig) {
+                def loggingType = dockerExecutor.loadClass('com.github.dockerjava.api.model.LogConfig$LoggingType').values().find {
+                    it.type == logConfig
+                }
+                cmd.withLogConfig(dockerExecutor.loadClass('com.github.dockerjava.api.model.LogConfig').newInstance(loggingType))
             }
 
             def result = cmd.withName(containerName).exec()

--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/container/DcomposeContainerCreateTask.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/container/DcomposeContainerCreateTask.groovy
@@ -269,6 +269,12 @@ class DcomposeContainerCreateTask extends AbstractDcomposeServiceTask {
         service.logConfig
     }
 
+    @Input
+    @Optional
+    Map<String, String> getLogOpts() {
+        service.logOpts
+    }
+
     @TaskAction
     @TypeChecked(TypeCheckingMode.SKIP)
     void createNewContainer() {
@@ -409,7 +415,9 @@ class DcomposeContainerCreateTask extends AbstractDcomposeServiceTask {
                 def loggingType = dockerExecutor.loadClass('com.github.dockerjava.api.model.LogConfig$LoggingType').values().find {
                     it.type == logConfig
                 }
-                cmd.withLogConfig(dockerExecutor.loadClass('com.github.dockerjava.api.model.LogConfig').newInstance(loggingType))
+                def logConfClass = dockerExecutor.loadClass('com.github.dockerjava.api.model.LogConfig')
+                def args = logOpts ? [loggingType, logOpts] : [loggingType]
+                cmd.withLogConfig(logConfClass.newInstance(*args))
             }
 
             def result = cmd.withName(containerName).exec()

--- a/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTaskSpec.groovy
+++ b/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTaskSpec.groovy
@@ -89,7 +89,8 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     restart = 'always'
                     dependsOn = [other]
                     memLimit = 1000000000L
-                    logConfig = 'json-file'
+                    logConfig = 'syslog'
+                    logOpts = ['syslog-address': 'tcp://192.168.0.42:123']
                 }
             }
             createComposeFile.version = '2'
@@ -155,11 +156,13 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     aliases:
                     - netalias
                     - netalias2
+                logging:
+                  driver: syslog
+                  options:
+                    syslog-address: tcp://192.168.0.42:123
                 volumes_from:
                 - other
                 mem_limit: 1000000000
-                logging:
-                  driver: json-file
               other:
                 image: $registryUrl/comfil-all@sha256:...
                 networks:
@@ -243,7 +246,8 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     restart = 'always'
                     dependsOn = [other]
                     memLimit = 1000000000L
-                    logConfig = 'json-file'
+                    logConfig = 'fluentd'
+                    logOpts = ['fluentd-address': 'fluentdhost:24224']
                 }
             }
         """
@@ -308,13 +312,15 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     aliases:
                     - netalias
                     - netalias2
+                logging:
+                  driver: fluentd
+                  options:
+                    fluentd-address: fluentdhost:24224
                 deploy:
                   resources:
                     limits:
                       memory: '1000000000'
                     reservations: {}
-                logging:
-                  driver: json-file
               other:
                 image: $registryUrl/comfil-all@sha256:...
                 networks:
@@ -581,6 +587,7 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     repository = '$registryUrl/comfil-test/main:with-tag'
                     memLimit = 1000000000L
                     logConfig = 'json-file'
+                    logOpts = ['max-size': '200k', 'max-file': '10']
                 }
             }
             createComposeFile {
@@ -607,9 +614,12 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                 networks:
                   default:
                     aliases: []
-                mem_limit: 1000000000
                 logging:
                   driver: json-file
+                  options:
+                    max-size: 200k
+                    max-file: '10'
+                mem_limit: 1000000000
               third:
                 image: busybox@sha256:...
                 networks:

--- a/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTaskSpec.groovy
+++ b/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTaskSpec.groovy
@@ -313,6 +313,8 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     limits:
                       memory: '1000000000'
                     reservations: {}
+                logging:
+                  driver: json-file
               other:
                 image: $registryUrl/comfil-all@sha256:...
                 networks:

--- a/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTaskSpec.groovy
+++ b/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/tasks/DcomposeComposeFileTaskSpec.groovy
@@ -89,6 +89,7 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     restart = 'always'
                     dependsOn = [other]
                     memLimit = 1000000000L
+                    logConfig = 'json-file'
                 }
             }
             createComposeFile.version = '2'
@@ -157,6 +158,8 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                 volumes_from:
                 - other
                 mem_limit: 1000000000
+                logging:
+                  driver: json-file
               other:
                 image: $registryUrl/comfil-all@sha256:...
                 networks:
@@ -240,6 +243,7 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     restart = 'always'
                     dependsOn = [other]
                     memLimit = 1000000000L
+                    logConfig = 'json-file'
                 }
             }
         """
@@ -574,6 +578,7 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                     dependsOn = [third]
                     repository = '$registryUrl/comfil-test/main:with-tag'
                     memLimit = 1000000000L
+                    logConfig = 'json-file'
                 }
             }
             createComposeFile {
@@ -601,6 +606,8 @@ class DcomposeComposeFileTaskSpec extends AbstractDcomposeSpec {
                   default:
                     aliases: []
                 mem_limit: 1000000000
+                logging:
+                  driver: json-file
               third:
                 image: busybox@sha256:...
                 networks:


### PR DESCRIPTION
I would like to add support for the container log driver and options, see [dcompose-logging-example](https://github.com/sgdan/dcompose-logging-example) for an example which uses the fluentd logging driver and tag option to send container logs to the EFK stack.