### PR TITLE
Parse image refs with more than two slashes

### DIFF
--- a/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/utils/ImageRef.groovy
+++ b/src/main/groovy/com/chrisgahlert/gradledcomposeplugin/utils/ImageRef.groovy
@@ -31,9 +31,9 @@ class ImageRef implements Serializable {
     static ImageRef parse(String image) {
         def parts = image.split('/')
         def registry, repositoryWithTag
-        if (parts.length == 3) {
-            registry = parts[0]
-            repositoryWithTag = parts[1] + '/' + parts[2]
+        if (parts.length >= 3) {
+            registry = parts.first()
+            repositoryWithTag = parts.drop(1).join("/")
         } else if (parts.length == 2) {
             if (parts[0].contains(':') || parts[0].contains('.')) {
                 registry = parts[0]

--- a/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/utils/ImageRefSpec.groovy
+++ b/src/test/groovy/com/chrisgahlert/gradledcomposeplugin/utils/ImageRefSpec.groovy
@@ -1,0 +1,27 @@
+package com.chrisgahlert.gradledcomposeplugin.utils
+
+import org.gradle.api.GradleException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ImageRefSpec extends Specification {
+
+    @Unroll
+    def "should parse #image"() {
+        when:
+        def ref = ImageRef.parse(image)
+
+        then:
+        notThrown(GradleException)
+        ref.registry == registry
+        ref.repository == repository
+        ref.tag == tag
+
+        where:
+        image                                || registry      | repository           | tag
+        'nginx:latest'                       || null          | 'nginx'              | 'latest'
+        'registry:2.7.1'                     || null          | 'registry'           | '2.7.1'
+        "example.com/stuff/java:15"          || 'example.com' | 'stuff/java'         | '15'
+        "example.com/proxy/stuff/server:3.4" || 'example.com' | 'proxy/stuff/server' | '3.4'
+    }
+}


### PR DESCRIPTION
We have a dockerhub proxy here that creates image refs with a lot of slashes.  The ImageRef class couldn't cope with that.  Here's a fix :) 